### PR TITLE
Add basic controller and DAO tests

### DIFF
--- a/src/test/java/com/example/transaction/controller/InstallmentControllerTest.java
+++ b/src/test/java/com/example/transaction/controller/InstallmentControllerTest.java
@@ -1,0 +1,53 @@
+package com.example.transaction.controller;
+
+import com.example.transaction.model.Installment;
+import com.example.transaction.service.InstallmentService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.util.StreamUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(InstallmentController.class)
+class InstallmentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private InstallmentService installmentService;
+
+    private String readFixture(String name) throws Exception {
+        return StreamUtils.copyToString(
+                getClass().getClassLoader().getResourceAsStream("fixtures/" + name),
+                StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void getInstallmentsReturnsList() throws Exception {
+        List<Installment> installments = Arrays.asList(
+                new Installment(1L, 1L, 10L),
+                new Installment(2L, 1L, 50L),
+                new Installment(3L, 1L, 40L)
+        );
+        when(installmentService.getInstallmentsForTransactions(anyLong()))
+                .thenReturn(ResponseEntity.ok(installments));
+
+        String expectedJson = readFixture("installments_list.json");
+        mockMvc.perform(get("/installment/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(expectedJson));
+    }
+}

--- a/src/test/java/com/example/transaction/controller/TransactionControllerTest.java
+++ b/src/test/java/com/example/transaction/controller/TransactionControllerTest.java
@@ -1,0 +1,77 @@
+package com.example.transaction.controller;
+
+import com.example.transaction.model.Installment;
+import com.example.transaction.model.Transaction;
+import com.example.transaction.model.TransactionDetails;
+import com.example.transaction.model.TransactionsResponse;
+import com.example.transaction.service.TransactionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.util.StreamUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TransactionController.class)
+class TransactionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TransactionService transactionService;
+
+    private String readFixture(String name) throws Exception {
+        return StreamUtils.copyToString(
+                getClass().getClassLoader().getResourceAsStream("fixtures/" + name),
+                StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void getAllTransactionsReturnsResponse() throws Exception {
+        List<Transaction> transactions = Arrays.asList(
+                new Transaction(1L, "ABC", "XYZ", 200L, 100L),
+                new Transaction(2L, "XYZ", "MNP", 100L, 100L)
+        );
+        TransactionsResponse response = new TransactionsResponse(transactions, 2L);
+        when(transactionService.getAllTransactions(anyLong(), anyString()))
+                .thenReturn(ResponseEntity.ok(response));
+
+        String expectedJson = readFixture("transactions_response.json");
+        mockMvc.perform(get("/transaction")
+                        .param("pageNumber", "0")
+                        .param("sort", "asc"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(expectedJson));
+    }
+
+    @Test
+    void getTransactionDetailsReturnsResponse() throws Exception {
+        Transaction transaction = new Transaction(1L, "ABC", "XYZ", 200L, 100L);
+        List<Installment> installments = Arrays.asList(
+                new Installment(1L, 1L, 10L),
+                new Installment(2L, 1L, 50L),
+                new Installment(3L, 1L, 40L)
+        );
+        TransactionDetails details = new TransactionDetails(transaction, installments);
+        when(transactionService.getTransactionData(anyLong()))
+                .thenReturn(ResponseEntity.ok(details));
+
+        String expectedJson = readFixture("transaction_details.json");
+        mockMvc.perform(get("/transaction/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(expectedJson));
+    }
+}

--- a/src/test/java/com/example/transaction/dao/InstallmentDaoTest.java
+++ b/src/test/java/com/example/transaction/dao/InstallmentDaoTest.java
@@ -1,0 +1,26 @@
+package com.example.transaction.dao;
+
+import com.example.transaction.model.Installment;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class InstallmentDaoTest {
+
+    @Test
+    void findReturnsInstallments() {
+        List<Installment> list = InstallmentDao.find(1L);
+        assertEquals(3, list.size());
+        assertEquals(1L, list.get(0).getParentId());
+    }
+
+    @Test
+    void findInstallmentSumReturnsTotal() {
+        Long sum = InstallmentDao.findInstallmentSum(1L);
+        assertEquals(100L, sum);
+    }
+}

--- a/src/test/java/com/example/transaction/dao/TransactionDaoTest.java
+++ b/src/test/java/com/example/transaction/dao/TransactionDaoTest.java
@@ -1,0 +1,32 @@
+package com.example.transaction.dao;
+
+import com.example.transaction.model.TransactionsResponse;
+import com.example.transaction.model.Transaction;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class TransactionDaoTest {
+
+    @Autowired
+    private TransactionDao transactionDao;
+
+    @Test
+    void findAllReturnsPagedTransactions() {
+        TransactionsResponse response = transactionDao.findAll(0L, "asc");
+        assertEquals(2, response.getTransactions().size());
+        assertEquals(7L, response.getTotalCount());
+        assertEquals(1L, response.getTransactions().get(0).getId());
+        assertEquals(2L, response.getTransactions().get(1).getId());
+    }
+
+    @Test
+    void findByIdReturnsTransaction() {
+        Transaction t = transactionDao.find(3L);
+        assertNotNull(t);
+        assertEquals(3L, t.getId());
+    }
+}

--- a/src/test/resources/fixtures/installments_list.json
+++ b/src/test/resources/fixtures/installments_list.json
@@ -1,0 +1,5 @@
+[
+  { "id": 1, "parentId": 1, "paidAmount": 10 },
+  { "id": 2, "parentId": 1, "paidAmount": 50 },
+  { "id": 3, "parentId": 1, "paidAmount": 40 }
+]

--- a/src/test/resources/fixtures/transaction_details.json
+++ b/src/test/resources/fixtures/transaction_details.json
@@ -1,0 +1,14 @@
+{
+  "transaction": {
+    "id": 1,
+    "sender": "ABC",
+    "receiver": "XYZ",
+    "totalAmount": 200,
+    "totalPaidAmount": 100
+  },
+  "installments": [
+    { "id": 1, "parentId": 1, "paidAmount": 10 },
+    { "id": 2, "parentId": 1, "paidAmount": 50 },
+    { "id": 3, "parentId": 1, "paidAmount": 40 }
+  ]
+}

--- a/src/test/resources/fixtures/transactions_response.json
+++ b/src/test/resources/fixtures/transactions_response.json
@@ -1,0 +1,19 @@
+{
+  "transactions": [
+    {
+      "id": 1,
+      "sender": "ABC",
+      "receiver": "XYZ",
+      "totalAmount": 200,
+      "totalPaidAmount": 100
+    },
+    {
+      "id": 2,
+      "sender": "XYZ",
+      "receiver": "MNP",
+      "totalAmount": 100,
+      "totalPaidAmount": 100
+    }
+  ],
+  "totalCount": 2
+}


### PR DESCRIPTION
## Summary
- create fixtures for controller tests
- add `TransactionControllerTest` and `InstallmentControllerTest` using `@WebMvcTest`
- add DAO tests for `TransactionDao` and `InstallmentDao`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6859bb49a2248321bea0310e29e97009