### PR TITLE
Add Swagger UI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Transaction-System is a **lightweight RESTful service** for managing parent-chil
 - 🗃️ **RESTful API**: CRUD-like operations for transactions and installments.
 - 📈 **Aggregate Computations**: Calculates sum of child payments per parent on the fly.
 - 📦 **Standalone JAR & Docker**: Run locally or in a container via the provided `Dockerfile`.
+- 📝 **Swagger UI**: Interactive API docs available at `/swagger-ui.html`.
 
 ---
 
@@ -141,6 +142,8 @@ curl http://localhost:8080/parent/1
 # → { "id":1, "sender":"Alice", "receiver":"Bob", "totalAmount":1000, "sumPaid":200 }
 ```
 
+Visit `http://localhost:8080/swagger-ui.html` for interactive API documentation.
+
 ---
 
 ## 🛡️ Error Handling & Validation
@@ -160,7 +163,7 @@ curl http://localhost:8080/parent/1
 
 ## 🗺️ Roadmap
 - [ ] Persist data in **PostgreSQL** or **H2** instead of JSON files.
-- [ ] Add **Swagger/OpenAPI** documentation at `/swagger-ui.html`.
+- [x] Add **Swagger/OpenAPI** documentation at `/swagger-ui.html`.
 - [ ] Implement **CRUD** endpoints for POST/PUT/DELETE.
 - [ ] Introduce **security** with Spring Security (JWT).
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,11 @@
             <artifactId>json-simple</artifactId>
             <version>1.1.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.7.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/example/transaction/config/OpenAPIConfig.java
+++ b/src/main/java/com/example/transaction/config/OpenAPIConfig.java
@@ -1,0 +1,16 @@
+package com.example.transaction.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAPIConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info().title("Transaction API").version("1.0"));
+    }
+}


### PR DESCRIPTION
## Summary
- document Swagger in README
- include `springdoc-openapi-ui` dependency
- expose API docs via new `OpenAPIConfig`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6859bbbc6c24832183651b0aee332869